### PR TITLE
Remove "es5:true" option from .jshintrc

### DIFF
--- a/root/.jshintrc
+++ b/root/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }


### PR DESCRIPTION
This option makes jshint fail because it's default in current jshint.
