### PR TITLE
fixes #10 by updating devDependencies to current versions and switching ...

### DIFF
--- a/template.js
+++ b/template.js
@@ -62,9 +62,9 @@ exports.template = function(grunt, init, done) {
     props.npm_test = 'grunt test';
     props.keywords = ['gruntplugin'];
     props.devDependencies = {
-      'grunt-contrib-jshint': '~0.6.0',
-      'grunt-contrib-clean': '~0.4.0',
-      'grunt-contrib-nodeunit': '~0.2.0',
+      'grunt-contrib-jshint': '^0.9.2',
+      'grunt-contrib-clean': '^0.5.0',
+      'grunt-contrib-nodeunit': '^0.3.3',
     };
     props.peerDependencies = {
       'grunt': props.grunt_version,


### PR DESCRIPTION
I updated the version numbers and changed the dependencies from minor to major releases. (`'~0.4.0'` to `'^0.5.0'`)

Since these are grunt-contrib-\* packages I am assuming we can trust that minor releases wont break the API. That might be wrong though.
